### PR TITLE
Remove static calls to TestCase::getUniqueTmpDirectory()

### DIFF
--- a/tests/Composer/Test/AllFunctionalTest.php
+++ b/tests/Composer/Test/AllFunctionalTest.php
@@ -53,15 +53,17 @@ class AllFunctionalTest extends TestCase
         }
     }
 
+    /** TestCase garbage collector
+    */
+    private static $testCaseGc;
+
     public static function setUpBeforeClass()
     {
-        self::$pharPath = self::getUniqueTmpDirectory() . '/composer.phar';
-    }
+        if (!isset(self::$testCaseGc)) {
+            self::$testCaseGc = new self();
+        }
 
-    public static function tearDownAfterClass()
-    {
-        $fs = new Filesystem;
-        $fs->removeDirectory(dirname(self::$pharPath));
+        self::$pharPath = self::$testCaseGc->getUniqueTmpDirectory() . '/composer.phar';
     }
 
     public function testBuildPhar()

--- a/tests/Composer/Test/Mock/FactoryMock.php
+++ b/tests/Composer/Test/Mock/FactoryMock.php
@@ -18,16 +18,24 @@ use Composer\Repository\RepositoryManager;
 use Composer\Repository\WritableRepositoryInterface;
 use Composer\Installer;
 use Composer\IO\IOInterface;
-use Composer\TestCase;
+use Composer\Test\TestCaseGC;
 
 class FactoryMock extends Factory
 {
+    /** TestCase garbage collector
+    */
+    private static $testCaseGc;
+
     public static function createConfig(IOInterface $io = null, $cwd = null)
     {
+        if (!isset(self::$testCaseGc)) {
+            self::$testCaseGc = new TestCaseGC();
+        }
+
         $config = new Config(true, $cwd);
 
         $config->merge(array(
-            'config' => array('home' => TestCase::getUniqueTmpDirectory()),
+            'config' => array('home' => self::$testCaseGc->getUniqueTmpDirectory()),
             'repositories' => array('packagist' => false),
         ));
 

--- a/tests/Composer/Test/TestCaseGC.php
+++ b/tests/Composer/Test/TestCaseGC.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Test;
+
+use Composer\TestCase;
+
+class TestCaseGC extends TestCase {}

--- a/tests/Composer/TestCase.php
+++ b/tests/Composer/TestCase.php
@@ -37,22 +37,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function __call($name, $arguments)
-    {
-        if ($name === 'getUniqueTmpDirectory') {
-            $this->tmpobjects[] = $result = call_user_func_array(__CLASS__ . "::$name", $arguments);
-            return $result;
-        } else {
-            return call_user_func_array(__CLASS__ . "::$name", $arguments);
-        }
-    }
-
-    public static function __callStatic($name, $arguments)
-    {
-        return call_user_func_array(__CLASS__ . "::$name", $arguments);
-    }
-
-    private static function getUniqueTmpDirectory()
+    public function getUniqueTmpDirectory()
     {
         $attempts = 5;
         $root = sys_get_temp_dir();
@@ -61,7 +46,8 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
             $unique = $root . DIRECTORY_SEPARATOR . uniqid('composer-test-' . rand(1000, 9000));
 
             if (!file_exists($unique) && Silencer::call('mkdir', $unique, 0777)) {
-                return realpath($unique);
+                $this->tmpobjects[] = $result = realpath($unique);
+                return $result;
             }
         } while (--$attempts);
 


### PR DESCRIPTION
Remove static calls to TestCase::getUniqueTmpDirectory() to allow automatic garbage collection.